### PR TITLE
Add data_science environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ Copy of `py3_latest` but with Python version forced to 3.6 for compatibility wit
 Copy of `py3_latest` but with the latest version of Python 2. Use:
 
 `conda activate py2_latest`
+
+### Data Science  (`data_science`)
+
+Extension of `py3_latest` environment with more advanced tools including `statsmodels` and `keras`. This environment was separated to avoid bloating `py3_latest`.

--- a/data_science.yml
+++ b/data_science.yml
@@ -1,0 +1,14 @@
+name: data_science
+dependencies:
+  - python>=3.7
+  - numpy
+  - pandas
+  - scipy
+  - scikit-learn
+  - matplotlib
+  - seaborn
+  - cython
+  - h5py
+  - statsmodels
+  - keras
+  - pip


### PR DESCRIPTION
An extension of `py3_latest` to keep `py3_latest` from becoming bloated which can lead to older versions of packages being necessary for compatibility.