### PR TITLE
Fix Tensorflow 2 not compatible with other packages

### DIFF
--- a/data_science.yml
+++ b/data_science.yml
@@ -12,7 +12,7 @@ dependencies:
   - statsmodels
   - keras
   - bokeh
-  - tensorflow>=2.0
+  - tensorflow
   - pip
   - pip:
     - pytest


### PR DESCRIPTION
Looks like you have to do some technical jiggery-pokery to make Tensorflow 2 actually work in that environment, relaxing the requirement for 2+ to allow things to function.