### PR TITLE
Fix pdoc dependency

### DIFF
--- a/data_science.yml
+++ b/data_science.yml
@@ -17,4 +17,4 @@ dependencies:
   - pip
   - pip:
     - pytest
-    - pdoc
+    - pdoc3

--- a/py3_6.yml
+++ b/py3_6.yml
@@ -12,4 +12,4 @@ dependencies:
   - pip
   - pip:
     - pytest
-    - pdoc
+    - pdoc3

--- a/py3_latest.yml
+++ b/py3_latest.yml
@@ -12,4 +12,4 @@ dependencies:
   - pip
   - pip:
     - pytest
-    - pdoc
+    - pdoc3


### PR DESCRIPTION
`pdoc` is no longer maintained and has been superseded by `pdoc3`.